### PR TITLE
Allow connecting with Kerberos/SSO

### DIFF
--- a/sqlalchemy_pytds/connector.py
+++ b/sqlalchemy_pytds/connector.py
@@ -109,6 +109,9 @@ class PyTDSConnector(Connector):
                 del connect_args["auth_method"]
                 del connect_args["user"]
                 del connect_args["password"]
+            elif connect_args["auth_method"] == "sso":
+                connect_args["use_sso"] = True
+                del connect_args["auth_method"]
             else:
                 raise Exception("Unknown auth_method " + connect_args["auth_method"])
 


### PR DESCRIPTION
PyTDS supports Kerberos with with connect parameter "use_sso=True". This change allows to use this from SQLAlchemy, e.g.
```python3
engine = sqlalchemy.create_engine(r'mssql+pytds://SERVER_FQDN\INSTANCE_NAME/DB_NAME?auth_method=sso')
```
On Windows, it should just work in a Active Directory network. On Linux, one has to install `pykerberos` and create a Kerberos ticket with `kinit`.