### PR TITLE
feat: make `host` param optional

### DIFF
--- a/sqlalchemy_pytds/connector.py
+++ b/sqlalchemy_pytds/connector.py
@@ -96,8 +96,7 @@ class PyTDSConnector(Connector):
             if param in keys:
                 connect_args[param] = keys.pop(param)
 
-        connect_args["dsn"] = connect_args["host"]
-        del connect_args["host"]
+        connect_args["dsn"] = connect_args.pop("host", "localhost")
 
         if "auth_method" in connect_args:
             if connect_args["auth_method"] == "mssql":


### PR DESCRIPTION
Closes #8 

By using `dict.pop` here we can avoid key errors when the `host` field is not required such as some implementations of when the `creator` argument is used alongside `sqlalchemy.create_engine`